### PR TITLE
Add a downlod link if enclosure path is available

### DIFF
--- a/src/_layouts/post.njk
+++ b/src/_layouts/post.njk
@@ -54,6 +54,11 @@ layout: base.njk
               Your browser does not support the audio tag.
             </audio>
           </div>
+          {% if enclosure.split(" ")[0] and enclosure.split(" ")[0] !== '' %}
+            <div class="tdbc-download-link">
+              <a href="{{ enclosure.split(" ")[0] }}" download class="tdbc-button">Download Episode</a>
+            </div>
+          {% endif %}
         {% endif %}
       </div>
       <div class="tdbc-section--padded">


### PR DESCRIPTION
  This PR adds a download link for podcast episodes that:
  - Only appears when an enclosure URL is available
  - Validates that the enclosure path exists and is not empty
  - Uses the same URL as the audio player
  - Includes a download attribute for proper file downloading
  - Is styled consistently with the site's design system