### PR TITLE
Update HF283 track listing with podcast and youtube links

### DIFF
--- a/src/posts/2025-08-01-hf283-with-taylan.md
+++ b/src/posts/2025-08-01-hf283-with-taylan.md
@@ -6,7 +6,7 @@ categories:
 author: "Taylan"
 tags:
   - "taylan"
-  - “guest-mix”
+  - "guest-mix"
 enclosure: "https://op3.dev/e/pinecast.com/listen/d4352333-143c-4bf6-ae0c-ca9af2201b89.mp3?source=rss&ext=asset.mp3 72078757 audio/mpeg"
 coverImage: "HF283_with_Taylan.jpg"
 redirectFrom: "/hf283"
@@ -15,29 +15,37 @@ season: 3
 explicit: "no"
 duration: "01:14:54"
 ---
-This week’s episode features Taylan, a young new talent making waves in the house scene with his debut mix for House Finesse as part of our 20th anniversary series. 
+This week's episode features Taylan, a young new talent making waves in the house scene with his debut mix for House Finesse as part of our 20th anniversary series. 
 
-You might’ve caught him recently warming up the dancefloor at a low-key industry party – now he’s bringing that same raw energy to the podcast. Expect heads-down grooves, dubby textures, and some seriously weighty rollers.
+You might've caught him recently warming up the dancefloor at a low-key industry party – now he's bringing that same raw energy to the podcast. Expect heads-down grooves, dubby textures, and some seriously weighty rollers.
 
-Includes an exclusive spin of Sakura’s “Dance With Me” – heard here first.
+Includes an exclusive spin of Sakura's "Dance With Me" – heard here first.
+
+## Listen on [Apple Podcasts](https://podcasts.apple.com/gb/podcast/hf283-with-taylan-1-aug-2025/id355833875?i=1000720000000)
+
+<iframe allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write" frameborder="0" height="175" style="width:100%;max-width:660px;overflow:hidden;border-radius:10px;" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" src="https://embed.podcasts.apple.com/gb/podcast/hf283-with-taylan-1-aug-2025/id355833875?i=1000720000000"></iframe>
+
+## Watch on [YouTube](https://www.youtube.com/watch?v=7XH0Ppv0ZcE)
+
+<div style="position:relative;width:100%;max-width:660px;aspect-ratio:16/9;margin-bottom:1em;"><iframe src="https://www.youtube.com/embed/7XH0Ppv0ZcE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style="width:100%;height:100%;position:absolute;top:0;left:0;"></iframe></div>
 
 ## Track Listing
 
-Job De Jong – Don’t Wanna Stop, Dub Stop
-Dale Howard – Nasty 90’s
-Ranger Trucco – Big Wreckage
-Sidney Charles, Theo Nasa, Kolter – Last One Standing
-Job De Jong – Dub House (Kepler Remix)
-Sosa – Painless Love
-Candidate (UK) – Spirit Sermon
-Chopper (UK) – The District
-Julian Fijma – Keep It Going
-Luke Dean – Get Busy
-Julian Fijma – Slammin
-Dan Fresco – Shake The Walls
-Watchers – Ultra Bright
-Daetor – No Hiding
-Sakura – Dance With Me (Unreleased)
-L.P. Rhythm – Versatile
-Tommy Phillips – Fixation
+1. Job De Jong – Don't Wanna Stop, Dub Stop
+2. Dale Howard – Nasty 90's
+3. Ranger Trucco – Big Wreckage
+4. Sidney Charles, Theo Nasa, Kolter – Last One Standing
+5. Job De Jong – Dub House (Kepler Remix)
+6. Sosa – Painless Love
+7. Candidate (UK) – Spirit Sermon
+8. Chopper (UK) – The District
+9. Julian Fijma – Keep It Going
+10. Luke Dean – Get Busy
+11. Julian Fijma – Slammin
+12. Dan Fresco – Shake The Walls
+13. Watchers – Ultra Bright
+14. Daetor – No Hiding
+15. Sakura – Dance With Me (Unreleased)
+16. L.P. Rhythm – Versatile
+17. Tommy Phillips – Fixation
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Format HF283 track listing as a numbered list and add Apple Podcasts and YouTube embeds.

---
<a href="https://cursor.com/background-agent?bcId=bc-c38298c3-25a1-4892-b32b-33389f76a02e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c38298c3-25a1-4892-b32b-33389f76a02e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>