### PR TITLE
Update hf283 Apple podcast link

### DIFF
--- a/src/posts/2025-08-01-hf283-with-taylan.md
+++ b/src/posts/2025-08-01-hf283-with-taylan.md
@@ -21,9 +21,9 @@ You might've caught him recently warming up the dancefloor at a low-key industry
 
 Includes an exclusive spin of Sakura's "Dance With Me" – heard here first.
 
-## Listen on [Apple Podcasts](https://podcasts.apple.com/gb/podcast/hf283-with-taylan-1-aug-2025/id355833875?i=1000720000000)
+## Listen on [Apple Podcasts](https://podcasts.apple.com/gb/podcast/house-finesse/id355833875?i=1000720168259)
 
-<iframe allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write" frameborder="0" height="175" style="width:100%;max-width:660px;overflow:hidden;border-radius:10px;" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" src="https://embed.podcasts.apple.com/gb/podcast/hf283-with-taylan-1-aug-2025/id355833875?i=1000720000000"></iframe>
+<iframe allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write" frameborder="0" height="175" style="width:100%;max-width:660px;overflow:hidden;border-radius:10px;" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" src="https://embed.podcasts.apple.com/gb/podcast/house-finesse/id355833875?i=1000720168259"></iframe>
 
 ## Watch on [YouTube](https://www.youtube.com/watch?v=7XH0Ppv0ZcE)
 


### PR DESCRIPTION
Update hf283 Apple Podcasts link to the correct episode URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5d416cf-d769-42aa-b222-c75dfc39de21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5d416cf-d769-42aa-b222-c75dfc39de21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>