### PR TITLE
Generate posts calendar feed

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,6 +32,27 @@ module.exports = function (eleventyConfig) {
       const filtered = collection.filter(item => item.data.category == category)
       return filtered;
   });
+
+  // ICS Calendar filters
+  eleventyConfig.addFilter('dateToRfc3339', function(date) {
+    return new Date(date).toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+  });
+
+  eleventyConfig.addFilter('escapeIcs', function(str) {
+    if (!str) return '';
+    return str
+      .replace(/\\/g, '\\\\')
+      .replace(/;/g, '\\;')
+      .replace(/,/g, '\\,')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\t/g, '\\t');
+  });
+
+  eleventyConfig.addFilter('stripHtml', function(str) {
+    if (!str) return '';
+    return str.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+  });
   
   // Authors collection grouped by frontmatter `author`
   eleventyConfig.addCollection('authors', (collectionApi) => {

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -194,6 +194,11 @@
                 1.228l.518.869.519-.869c.533-.819 1.34-1.228 2.405-1.228.92 0 1.662.324 2.228.955.549.631.822 1.484.822 2.558v5.253z"/>
               </svg>
             </a>
+            <a href="/shows.ics" class="tdbc-icon-button tdbc-ink--light" aria-label="Calendar Feed">
+              <svg fill="#FFFFFF" width="800px" height="800px" viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
+              </svg>
+            </a>
           </span>
           <p>
             <a href="https://github.com/si/hf" title="Versioned on Github">v{{ pkg.version }}</a>,

--- a/src/shows.ics.njk
+++ b/src/shows.ics.njk
@@ -1,0 +1,28 @@
+---
+permalink: /shows.ics
+eleventyExcludeFromCollections: true
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//House Finesse//Calendar Feed//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:House Finesse Shows
+X-WR-CALDESC:House Finesse podcast episodes
+{% for post in collections.posts | reverse %}
+BEGIN:VEVENT
+UID:{{ post.url | slugify }}@housefinesse.com
+DTSTAMP:{{ post.date | dateToRfc3339 }}
+DTSTART:{{ post.date | dateToRfc3339 }}
+DTEND:{{ post.date | dateToRfc3339 }}
+SUMMARY:{{ post.data.title | escapeIcs }}
+DESCRIPTION:{{ post.data.title | escapeIcs }}
+
+{{ post.templateContent | stripHtml | escapeIcs }}
+
+Listen at: {{ meta.url }}{{ post.url }}
+LOCATION:{{ meta.url }}{{ post.url }}
+URL:{{ meta.url }}{{ post.url }}
+END:VEVENT
+{% endfor %}
+END:VCALENDAR


### PR DESCRIPTION
Add an ICS calendar feed for all posts, accessible at `/shows.ics`, with a link in the footer.

---
<a href="https://cursor.com/background-agent?bcId=bc-40d59190-07da-48a6-9146-a5bb5fa575ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40d59190-07da-48a6-9146-a5bb5fa575ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

