### PR TITLE
Add truefans link to podcast buttons

### DIFF
--- a/src/_includes/podcast_apps.njk
+++ b/src/_includes/podcast_apps.njk
@@ -19,6 +19,10 @@
         <img src="/img/icons/fountain-app-color.png" alt="Fountain" height="32">
         <span>Fountain</spam>
     </a>
+    <a href="https://truefans.fm/house-finesse" class="tdbc-button tdbc-icon-truefans">
+        <span style="font-size: 24px; font-weight: bold; color: #1a1a1a;">🎧</span>
+        <span>Truefans</span>
+    </a>
     <small style="text-align:center; display:block;">
         or just use
         <a href="https://housefinesse.com/feed/podcast/">our RSS feed</a>


### PR DESCRIPTION
Add a Truefans button to the podcast apps component.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f189b35-1e59-47f2-9d88-b04793cfd231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f189b35-1e59-47f2-9d88-b04793cfd231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

