### PR TITLE
Adjust homepage show card heading line height

### DIFF
--- a/src/css/_card.scss
+++ b/src/css/_card.scss
@@ -92,3 +92,13 @@
     box-shadow: none;
   }
 }
+
+.latest-shows {
+  h3 {
+    line-height: 0.5;
+  }
+
+  .tdbc-card__title {
+    line-height: 0.5;
+  }
+}

--- a/src/index.njk
+++ b/src/index.njk
@@ -33,9 +33,9 @@ redirectFrom: "/l386"
   </div>
 </header>
 <main class="tdbc-container">
-  <div class="tdbc-section">
+  <div class="tdbc-section latest-shows">
     <h2>Latest Shows</h2>
-    <ul class="tdbc-column-container">
+    <ul class="tdbc-column-container latest-shows__list">
       {%- set latest_posts = collections.posts | reverse -%}
       {%- for post in latest_posts.slice(0,12) -%}
         <li class="tdbc-card">


### PR DESCRIPTION
Set the line-height of h3 headings on the homepage's latest shows cards to 0.5.

---
<a href="https://cursor.com/background-agent?bcId=bc-e904130a-d498-425c-a3e6-44977f2cda5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e904130a-d498-425c-a3e6-44977f2cda5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

