### PR TITLE
Add shows archive page listing posts by year

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,8 +29,29 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addFilter('categoryFilter', function(collection, category) {
     if (!category) return collection;
-      const filtered = collection.filter(item => item.data.category == category)
-      return filtered;
+    const filtered = collection.filter(item => item.data.category == category)
+    return filtered;
+  });
+
+  eleventyConfig.addFilter("formatDate", function (dateObj, format = "dd-LL-yyyy") {
+    if (!dateObj) {
+      return "";
+    }
+
+    const date = new Date(dateObj);
+
+    if (Number.isNaN(date.getTime())) {
+      return "";
+    }
+
+    const pad = (value) => String(value).padStart(2, "0");
+    const tokens = {
+      yyyy: String(date.getUTCFullYear()),
+      LL: pad(date.getUTCMonth() + 1),
+      dd: pad(date.getUTCDate()),
+    };
+
+    return format.replace(/yyyy|LL|dd/g, (token) => tokens[token] ?? token);
   });
 
   // ICS Calendar filters

--- a/src/pages/shows.njk
+++ b/src/pages/shows.njk
@@ -1,0 +1,33 @@
+---
+title: "Shows"
+layout: "page"
+permalink: "/shows/"
+linkText: "Shows"
+---
+
+{% set posts = collections.posts | reverse %}
+{% set currentYear = null %}
+
+<div class="tdbc-stack tdbc-stack--lg">
+{% for post in posts %}
+  {% set postYear = post.date | formatDate("yyyy") %}
+  {% if postYear != currentYear %}
+    {% if currentYear %}
+      </ul>
+    </section>
+    {% endif %}
+    <section class="tdbc-stack tdbc-stack--md">
+      <h2 class="tdbc-h3 tdbc-mb-none">{{ postYear }}</h2>
+      <ul class="tdbc-stack tdbc-stack--sm tdbc-list--unstyled">
+    {% set currentYear = postYear %}
+  {% endif %}
+        <li class="tdbc-flex tdbc-flex--between tdbc-flex--wrap">
+          <a class="tdbc-link" href="{{ post.url }}">{{ post.data.title }}</a>
+          <span class="tdbc-ink--subtle">{{ post.date | formatDate("dd-LL-yyyy") }}</span>
+        </li>
+{% endfor %}
+{% if currentYear %}
+      </ul>
+    </section>
+{% endif %}
+</div>


### PR DESCRIPTION
## Summary
- add a dedicated /shows page that lists every post newest-first and groups them by year with short dates
- introduce a reusable Eleventy date formatting filter to support the archive display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e64e5f5730832cbb36cfed390b4b41