### PR TITLE
Redesign podcast app buttons with improved accessibility

### DIFF
--- a/src/_includes/podcast_apps.njk
+++ b/src/_includes/podcast_apps.njk
@@ -1,36 +1,36 @@
 <p>
-    <a href="https://podcasts.apple.com/gb/podcast/house-finesse/id355833875" class="tdbc-button tdbc-icon-apple">
+    <a href="https://podcasts.apple.com/gb/podcast/house-finesse/id355833875" title="Follow on Apple Podcasts" class="tdbc-button tdbc-icon-apple">
         <img src="/img/icons/apple-podcasts-color.svg" alt="Apple Podcasts" height="32">
-        <span>Apple Podcasts</span>
+        <span>Apple</span>
     </a>
-    <a href="https://www.youtube.com/housefinesse" class="tdbc-button tdbc-icon-youtube">
-        <img src="/img/icons/youtube-color.svg" alt="Youtube" height="32">
-        <span>Youtube Music</span>
+    <a href="https://www.youtube.com/housefinesse" title="Follow on Youtube Music" class="tdbc-button tdbc-icon-youtube">
+        <img src="/img/icons/youtube-color.svg" alt="Youtube Music" height="32">
+        <span>Youtube</span>
     </a>
-    <a href="https://open.spotify.com/show/3qwmnnogIeaiXG5HSKKdwU?si=_m_raNIDQk6kSoJn9_5efg" class="tdbc-button tdbc-icon-spotify">
+    <a href="https://open.spotify.com/show/3qwmnnogIeaiXG5HSKKdwU?si=_m_raNIDQk6kSoJn9_5efg" title="Follow on Spotify" class="tdbc-button tdbc-icon-spotify">
         <img src="/img/icons/spotify-color.svg" alt="Spotify" height="32">
         <span>Spotify</span>
     </a>
-    <a href="https://www.amazon.com/House-Finesse/dp/B08JJRH1Z2" class="tdbc-button tdbc-icon-amazon">
+    <a href="https://www.amazon.com/House-Finesse/dp/B08JJRH1Z2" title="Follow on Amazon Music" class="tdbc-button tdbc-icon-amazon">
         <img src="/img/icons/amazon-music-color.svg" alt="Amazon Music" height="32">
-        <span>Amazon Music</span>
+        <span>Amazon</span>
     </a>
-    <a href="https://tunein.com/podcasts/Music-Podcasts/House-Finesse-p1674150/" class="tdbc-button tdbc-icon-tunein">
+    <a href="https://tunein.com/podcasts/Music-Podcasts/House-Finesse-p1674150/" title="Follow on TuneIn" class="tdbc-button tdbc-icon-tunein">
         <img src="/img/icons/tunein-color.svg" alt="TuneIn" height="32">
-        <span>TuneIn</span>
+        <span>Tunein</span>
     </a>
     {% if followPage %}
-    <a href="https://truefans.fm/house-finesse" class="tdbc-button tdbc-icon-truefans">
+    <a href="https://truefans.fm/house-finesse" title="Follow on Truefans" class="tdbc-button tdbc-icon-truefans">
         <img src="/img/icons/truefans-user-color.svg" alt="Truefans" height="32">
         <span>Truefans</span>
     </a>
-    <a href="https://fountain.fm/show/jXEukzHtm2S2ZBdwRhLg" class="tdbc-button tdbc-icon-fountain">
+    <a href="https://fountain.fm/show/jXEukzHtm2S2ZBdwRhLg" title="Follow on Fountain" class="tdbc-button tdbc-icon-fountain">
         <img src="/img/icons/fountain-app-color.png" alt="Fountain" height="32">
         <span>Fountain</span>
     </a>
     {% endif %}
-
-    <small style="text-align:center; display:block;">
-        <a href="https://housefinesse.com/feed/podcast/" class="tdbc-button tdbc-button--small">RSS feed</a>
-    </small>
+    <a href="https://housefinesse.com/feed/podcast/" title="RSS podcast feed" class="tdbc-button tdbc-icon-rss">
+        <img src="/img/icons/rss-color.svg" alt="RSS" height="32">
+        <span>RSS</span>
+    </a>
 </p>

--- a/src/css/_buttons.scss
+++ b/src/css/_buttons.scss
@@ -9,8 +9,9 @@
   min-width: 10ch;
   min-height: 44px;
   padding: 0.25em 1em;
+  margin: 0.35em 0.4em;
   transition: 180ms ease-in-out;
-  transition-property: background, border;
+  transition-property: background, border, box-shadow;
   border-radius: $tdbc-border-radius * 1.5;
   background-color: tdbc-color("primary");
   color: #fff;
@@ -19,6 +20,10 @@
   text-align: center;
   text-decoration: none;
   cursor: pointer;
+
+  &:hover {
+    box-shadow: 0 0 0 3px #fff;
+  }
 
   img {
     margin-right: 0.5rem;
@@ -31,7 +36,7 @@
   &:focus {
     outline-color: transparent;
     outline-style: solid;
-    box-shadow: 0 0 0 3px scale-color(tdbc-color("primary"), $lightness: -30%);
+    box-shadow: 0 0 0 3px #fff;
   }
 
   &--small {

--- a/src/img/icons/rss-color.svg
+++ b/src/img/icons/rss-color.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#f26522"/>
+  <circle cx="6" cy="26" r="3" fill="white"/>
+  <path d="M6 18 a8 8 0 0 1 8 8" stroke="white" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <path d="M6 11 a15 15 0 0 1 15 15" stroke="white" stroke-width="3" stroke-linecap="round" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary
Redesigned the podcast app follow buttons to use a consistent icon-based layout with improved accessibility and visual feedback. The RSS feed link has been converted to match the button style, and button styling has been enhanced with better hover/focus states.

## Key Changes
- **Podcast app buttons**: Shortened button text labels (e.g., "Apple Podcasts" → "Apple") to create a more compact, icon-focused design
- **Accessibility improvements**: Added `title` attributes to all podcast platform links for better tooltip support
- **RSS feed redesign**: Converted the small text-based RSS link into a styled button matching other podcast platforms, with a new RSS icon
- **Button styling enhancements**:
  - Added consistent margin spacing (`0.35em 0.4em`) between buttons
  - Added hover state with white box-shadow for better visual feedback
  - Updated focus state to use white box-shadow instead of darkened primary color
  - Extended transition property to include `box-shadow` animations
- **New asset**: Added `rss-color.svg` icon with orange background and white RSS symbol

## Implementation Details
- All podcast platform links now follow the same visual pattern: icon + short text label
- Button hover and focus states now use a consistent white outline style for improved accessibility
- The RSS feed is now presented as a first-class button option alongside other podcast platforms rather than as secondary small text

https://claude.ai/code/session_01269AKU5qFipvkv14jYR1pZ