### PR TITLE
Add automated RSS feed to posts workflow

### DIFF
--- a/.github/workflows/rss-new-episode.yml
+++ b/.github/workflows/rss-new-episode.yml
@@ -26,53 +26,73 @@ jobs:
       - name: Fetch new episodes from RSS
         run: node scripts/rss-to-posts.js
         env:
-          # Override by adding RSS_FEED_URL as a repository secret or variable
-          RSS_FEED_URL: ${{ vars.RSS_FEED_URL || 'https://pinecast.com/feed/housefinesse' }}
+          # Override by setting RSS_FEED_URL as a repository variable
+          RSS_FEED_URL: ${{ vars.RSS_FEED_URL != '' && vars.RSS_FEED_URL || 'https://pinecast.com/feed/housefinesse' }}
 
       - name: Check for new files
         id: diff
         run: |
-          NEW=$(git ls-files --others --exclude-standard src/posts/)
-          if [ -n "$NEW" ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "files<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$NEW" >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
-          else
+          NEW_POSTS=$(git ls-files --others --exclude-standard src/posts/)
+          NEW_IMAGES=$(git ls-files --others --exclude-standard src/img/cover-images/)
+          NEW_ALL=$(printf '%s\n%s' "$NEW_POSTS" "$NEW_IMAGES" | grep -v '^$' || true)
+
+          if [ -z "$NEW_ALL" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+          # Derive branch name from first new post filename
+          FIRST_POST=$(echo "$NEW_POSTS" | head -1)
+          BASENAME=$(basename "$FIRST_POST" .md)
+          # Strip YYYY-MM-DD- prefix to get the episode slug
+          EPISODE_SLUG=$(echo "$BASENAME" | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}-//')
+          POST_COUNT=$(echo "$NEW_POSTS" | grep -c '.' || echo 0)
+
+          if [ "$POST_COUNT" -gt 1 ]; then
+            echo "branch=rss-episodes/$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=rss-episode/$EPISODE_SLUG" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Store file list for PR body
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NEW_ALL" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create branch and open PR
         if: steps.diff.outputs.found == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="rss-episode/$(date -u +%Y%m%d-%H%M%S)"
+          BRANCH="${{ steps.diff.outputs.branch }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add src/posts/
-          git commit -m "feat: add new episode(s) from RSS feed"
+          git add src/posts/ src/img/cover-images/
+          git commit -m "feat: add new episode from RSS feed ($BRANCH)"
           git push -u origin "$BRANCH"
 
           FILE_LIST=$(echo "${{ steps.diff.outputs.files }}" | sed 's/^/- /')
 
           {
-            echo "## New episode(s) detected from RSS feed"
+            echo "## New episode from RSS feed"
             echo ""
-            echo "Please review before merging:"
+            echo "Auto-generated from Pinecast RSS. Please review before merging:"
             echo ""
-            echo "- [ ] \`coverImage\` filename matches the uploaded image in \`src/img/cover-images/\`"
-            echo "- [ ] Description/body looks correct"
+            echo "- [ ] Post content and description look correct"
+            echo "- [ ] Cover image downloaded OK (check \`src/img/cover-images/\`)"
             echo "- [ ] Tags are accurate"
             echo ""
             echo "**New files:**"
             echo "$FILE_LIST"
           } > /tmp/pr-body.md
 
+          EPISODE_SLUG=$(echo "$BRANCH" | sed 's|rss-episode/||')
           gh pr create \
             --base main \
             --head "$BRANCH" \
-            --title "New episode(s) from RSS feed [$(date -u +%Y-%m-%d)]" \
+            --title "New episode: $EPISODE_SLUG" \
             --body-file /tmp/pr-body.md

--- a/.github/workflows/rss-new-episode.yml
+++ b/.github/workflows/rss-new-episode.yml
@@ -1,0 +1,78 @@
+name: RSS New Episode PR
+
+on:
+  schedule:
+    # Runs every 2 hours
+    - cron: '0 */2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-rss:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch new episodes from RSS
+        run: node scripts/rss-to-posts.js
+        env:
+          # Override by adding RSS_FEED_URL as a repository secret or variable
+          RSS_FEED_URL: ${{ vars.RSS_FEED_URL || 'https://pinecast.com/feed/housefinesse' }}
+
+      - name: Check for new files
+        id: diff
+        run: |
+          NEW=$(git ls-files --others --exclude-standard src/posts/)
+          if [ -n "$NEW" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "files<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$NEW" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create branch and open PR
+        if: steps.diff.outputs.found == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="rss-episode/$(date -u +%Y%m%d-%H%M%S)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add src/posts/
+          git commit -m "feat: add new episode(s) from RSS feed"
+          git push -u origin "$BRANCH"
+
+          FILE_LIST=$(echo "${{ steps.diff.outputs.files }}" | sed 's/^/- /')
+
+          {
+            echo "## New episode(s) detected from RSS feed"
+            echo ""
+            echo "Please review before merging:"
+            echo ""
+            echo "- [ ] \`coverImage\` filename matches the uploaded image in \`src/img/cover-images/\`"
+            echo "- [ ] Description/body looks correct"
+            echo "- [ ] Tags are accurate"
+            echo ""
+            echo "**New files:**"
+            echo "$FILE_LIST"
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "New episode(s) from RSS feed [$(date -u +%Y-%m-%d)]" \
+            --body-file /tmp/pr-body.md

--- a/scripts/rss-to-posts.js
+++ b/scripts/rss-to-posts.js
@@ -6,9 +6,11 @@ const path = require('path');
 
 const FEED_URL = process.env.RSS_FEED_URL || 'https://pinecast.com/feed/housefinesse';
 const POSTS_DIR = path.join(__dirname, '..', 'src', 'posts');
+const COVER_IMAGES_DIR = path.join(__dirname, '..', 'src', 'img', 'cover-images');
+
+// ─── XML helpers ─────────────────────────────────────────────────────────────
 
 function extractTag(xml, tag) {
-  // Handles optional namespace prefix (e.g. itunes:duration)
   const escaped = tag.replace(':', '\\:');
   const m = xml.match(new RegExp(`<${escaped}[^>]*>([\\s\\S]*?)<\\/${escaped}>`, 'i'));
   return m ? stripCdata(m[1].trim()) : '';
@@ -24,6 +26,62 @@ function stripCdata(str) {
   return str.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1').trim();
 }
 
+// ─── HTML → Markdown ─────────────────────────────────────────────────────────
+
+function htmlToMarkdown(html) {
+  if (!html) return '';
+  let md = html;
+
+  // Ordered lists (before stripping tags so we can count items)
+  md = md.replace(/<ol[^>]*>([\s\S]*?)<\/ol>/gi, (_, inner) => {
+    let n = 0;
+    return (
+      inner.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (__, content) => {
+        n++;
+        return `${n}. ${content.trim()}\n`;
+      }) + '\n'
+    );
+  });
+
+  // Unordered lists
+  md = md.replace(/<ul[^>]*>([\s\S]*?)<\/ul>/gi, (_, inner) => {
+    return (
+      inner.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (__, content) => {
+        return `- ${content.trim()}\n`;
+      }) + '\n'
+    );
+  });
+
+  // Block elements
+  md = md.replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, (_, c) => `${c.trim()}\n\n`);
+  md = md.replace(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi, (_, c) => `**${c.trim()}**\n\n`);
+  md = md.replace(/<br\s*\/?>/gi, '\n');
+
+  // Inline elements
+  md = md.replace(/<strong[^>]*>([\s\S]*?)<\/strong>/gi, '**$1**');
+  md = md.replace(/<b[^>]*>([\s\S]*?)<\/b>/gi, '**$1**');
+  md = md.replace(/<em[^>]*>([\s\S]*?)<\/em>/gi, '*$1*');
+  md = md.replace(/<i[^>]*>([\s\S]*?)<\/i>/gi, '*$1*');
+  md = md.replace(/<a[^>]*\shref="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi, '[$2]($1)');
+
+  // Strip remaining tags
+  md = md.replace(/<[^>]+>/g, '');
+
+  // Decode HTML entities
+  md = md
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)));
+
+  return md.replace(/\n{3,}/g, '\n\n').trim();
+}
+
+// ─── Field helpers ────────────────────────────────────────────────────────────
+
 function parseIsoDate(pubDate) {
   const d = new Date(pubDate);
   if (isNaN(d)) throw new Error(`Invalid date: ${pubDate}`);
@@ -38,28 +96,50 @@ function slugify(str) {
 }
 
 function extractEpisodeCode(title) {
-  // "HF322 with DJ Tai" -> "hf322"
   const m = title.match(/^(HF\d+)/i);
   return m ? m[1].toLowerCase() : null;
 }
 
-function deriveCoverImage(title, author) {
-  // "HF322", "Taiwo" -> "HF322_with_Taiwo.jpg"
-  const m = title.match(/^(HF\d+)/i);
-  if (!m) return '';
-  return `${m[1].toUpperCase()}_with_${author.replace(/\s+/g, '_')}.jpg`;
+// "hf322-with-taiwo" from episode code + itunes:author
+function episodeSlug(title, author) {
+  const code = extractEpisodeCode(title);
+  return code ? `${code}-with-${slugify(author)}` : slugify(title);
 }
 
-// Collect Pinecast UUIDs already referenced in existing posts to avoid duplicates
+// Strip filename from image URL (handles query strings)
+function imageFilename(url) {
+  if (!url) return '';
+  try {
+    return path.basename(new URL(url).pathname);
+  } catch {
+    return url.split('/').pop().split('?')[0];
+  }
+}
+
+// Normalize duration to HH:MM:SS — Pinecast uses seconds in some feeds
+function normalizeDuration(d) {
+  if (!d) return '';
+  if (/^\d{1,2}:\d{2}(:\d{2})?$/.test(d)) return d;
+  const secs = parseInt(d, 10);
+  if (!isNaN(secs) && String(secs) === d.trim()) {
+    const h = Math.floor(secs / 3600);
+    const m = Math.floor((secs % 3600) / 60);
+    const s = secs % 60;
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  }
+  return d;
+}
+
+// ─── Deduplication ───────────────────────────────────────────────────────────
+
 function getExistingPinecastIds() {
   const ids = new Set();
   if (!fs.existsSync(POSTS_DIR)) return ids;
   for (const entry of fs.readdirSync(POSTS_DIR, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
-    const yearDir = path.join(POSTS_DIR, entry.name);
-    for (const file of fs.readdirSync(yearDir)) {
+    for (const file of fs.readdirSync(path.join(POSTS_DIR, entry.name))) {
       if (!file.endsWith('.md')) continue;
-      const content = fs.readFileSync(path.join(yearDir, file), 'utf8');
+      const content = fs.readFileSync(path.join(POSTS_DIR, entry.name, file), 'utf8');
       const m = content.match(/pinecast\.com\/listen\/([a-f0-9-]{36})/);
       if (m) ids.add(m[1]);
     }
@@ -67,14 +147,41 @@ function getExistingPinecastIds() {
   return ids;
 }
 
-function buildFrontmatter(fields) {
+// ─── Image download ───────────────────────────────────────────────────────────
+
+async function downloadCoverImage(imageUrl) {
+  const filename = imageFilename(imageUrl);
+  if (!filename) return filename;
+
+  if (!fs.existsSync(COVER_IMAGES_DIR)) fs.mkdirSync(COVER_IMAGES_DIR, { recursive: true });
+  const destPath = path.join(COVER_IMAGES_DIR, filename);
+
+  if (fs.existsSync(destPath)) {
+    console.log(`  Cover image already present: ${filename}`);
+    return filename;
+  }
+
+  const res = await fetch(imageUrl, { headers: { 'User-Agent': 'house-finesse-rss-bot/1.0' } });
+  if (!res.ok) {
+    console.warn(`  Warning: could not download cover image (${res.status}): ${imageUrl}`);
+    return filename;
+  }
+  fs.writeFileSync(destPath, Buffer.from(await res.arrayBuffer()));
+  console.log(`  Downloaded cover image: ${filename}`);
+  return filename;
+}
+
+// ─── Post file ───────────────────────────────────────────────────────────────
+
+function buildPost(fields) {
+  const q = (s) => s.replace(/"/g, '\\"');
   const lines = [
     '---',
-    `title: "${fields.title.replace(/"/g, '\\"')}"`,
+    `title: "${q(fields.title)}"`,
     `date: "${fields.date}"`,
     'categories:',
     '  - "shows"',
-    `author: "${fields.author.replace(/"/g, '\\"')}"`,
+    `author: "${q(fields.author)}"`,
     'tags:',
     `  - "${slugify(fields.author)}"`,
   ];
@@ -85,19 +192,19 @@ function buildFrontmatter(fields) {
   if (fields.season) lines.push(`season: ${fields.season}`);
   lines.push(`explicit: "${fields.explicit || 'no'}"`);
   if (fields.duration) lines.push(`duration: "${fields.duration}"`);
-  lines.push('---', '', fields.description, '');
+  lines.push('---', '', fields.body, '');
   return lines.join('\n');
 }
 
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
 async function main() {
-  const res = await fetch(FEED_URL, {
-    headers: { 'User-Agent': 'house-finesse-rss-bot/1.0' },
-  });
+  const res = await fetch(FEED_URL, { headers: { 'User-Agent': 'house-finesse-rss-bot/1.0' } });
   if (!res.ok) throw new Error(`RSS fetch failed: ${res.status} ${res.statusText}`);
   const xml = await res.text();
 
-  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
   const items = [];
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
   let m;
   while ((m = itemRegex.exec(xml)) !== null) items.push(m[1]);
 
@@ -112,9 +219,7 @@ async function main() {
   for (const item of items) {
     const enclosureUrl = extractAttr(item, 'enclosure', 'url');
     const pinecastId = enclosureUrl.match(/pinecast\.com\/listen\/([a-f0-9-]{36})/)?.[1];
-
-    if (!pinecastId) continue;
-    if (existing.has(pinecastId)) continue;
+    if (!pinecastId || existing.has(pinecastId)) continue;
 
     const title = extractTag(item, 'title');
     const pubDate = extractTag(item, 'pubDate');
@@ -122,11 +227,12 @@ async function main() {
     const year = date.slice(0, 4);
 
     const author = extractTag(item, 'itunes:author') || extractTag(item, 'author');
-    const duration = extractTag(item, 'itunes:duration');
+    const duration = normalizeDuration(extractTag(item, 'itunes:duration'));
     const episode = extractTag(item, 'itunes:episode');
     const season = extractTag(item, 'itunes:season');
     const explicit = extractTag(item, 'itunes:explicit') || 'no';
-    const description = extractTag(item, 'description');
+    const rawDescription = extractTag(item, 'description');
+    const body = htmlToMarkdown(rawDescription);
 
     const enclosureLength = extractAttr(item, 'enclosure', 'length');
     const enclosureType = extractAttr(item, 'enclosure', 'type');
@@ -134,10 +240,12 @@ async function main() {
       ? `${enclosureUrl} ${enclosureLength} ${enclosureType}`.trim()
       : '';
 
-    const episodeCode = extractEpisodeCode(title);
-    const coverImage = deriveCoverImage(title, author);
-    const redirectFrom = episodeCode ? `/${episodeCode}` : '';
-    const slug = slugify(title);
+    const imageUrl = extractAttr(item, 'itunes:image', 'href');
+    const coverImage = await downloadCoverImage(imageUrl);
+
+    const epCode = extractEpisodeCode(title);
+    const slug = episodeSlug(title, author);
+    const redirectFrom = epCode ? `/${epCode}` : '';
     const filename = `${date}-${slug}.md`;
 
     const yearDir = path.join(POSTS_DIR, year);
@@ -149,30 +257,16 @@ async function main() {
       continue;
     }
 
-    const content = buildFrontmatter({
-      title,
-      date,
-      author,
-      enclosure,
-      coverImage,
-      redirectFrom,
-      episode,
-      season,
-      explicit,
-      duration,
-      description,
-    });
-
-    fs.writeFileSync(filepath, content, 'utf8');
+    fs.writeFileSync(
+      filepath,
+      buildPost({ title, date, author, enclosure, coverImage, redirectFrom, episode, season, explicit, duration, body }),
+      'utf8',
+    );
     console.log(`Created: src/posts/${year}/${filename}`);
     created++;
   }
 
-  if (created === 0) {
-    console.log('No new episodes found.');
-  } else {
-    console.log(`Done. Created ${created} new post(s).`);
-  }
+  console.log(created === 0 ? 'No new episodes found.' : `Done. Created ${created} new post(s).`);
 }
 
 main().catch((err) => {

--- a/scripts/rss-to-posts.js
+++ b/scripts/rss-to-posts.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const FEED_URL = process.env.RSS_FEED_URL || 'https://pinecast.com/feed/housefinesse';
+const POSTS_DIR = path.join(__dirname, '..', 'src', 'posts');
+
+function extractTag(xml, tag) {
+  // Handles optional namespace prefix (e.g. itunes:duration)
+  const escaped = tag.replace(':', '\\:');
+  const m = xml.match(new RegExp(`<${escaped}[^>]*>([\\s\\S]*?)<\\/${escaped}>`, 'i'));
+  return m ? stripCdata(m[1].trim()) : '';
+}
+
+function extractAttr(xml, tag, attr) {
+  const escaped = tag.replace(':', '\\:');
+  const m = xml.match(new RegExp(`<${escaped}[^>]*\\s${attr}="([^"]*)"`, 'i'));
+  return m ? m[1] : '';
+}
+
+function stripCdata(str) {
+  return str.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1').trim();
+}
+
+function parseIsoDate(pubDate) {
+  const d = new Date(pubDate);
+  if (isNaN(d)) throw new Error(`Invalid date: ${pubDate}`);
+  return d.toISOString().split('T')[0];
+}
+
+function slugify(str) {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function extractEpisodeCode(title) {
+  // "HF322 with DJ Tai" -> "hf322"
+  const m = title.match(/^(HF\d+)/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function deriveCoverImage(title, author) {
+  // "HF322", "Taiwo" -> "HF322_with_Taiwo.jpg"
+  const m = title.match(/^(HF\d+)/i);
+  if (!m) return '';
+  return `${m[1].toUpperCase()}_with_${author.replace(/\s+/g, '_')}.jpg`;
+}
+
+// Collect Pinecast UUIDs already referenced in existing posts to avoid duplicates
+function getExistingPinecastIds() {
+  const ids = new Set();
+  if (!fs.existsSync(POSTS_DIR)) return ids;
+  for (const entry of fs.readdirSync(POSTS_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const yearDir = path.join(POSTS_DIR, entry.name);
+    for (const file of fs.readdirSync(yearDir)) {
+      if (!file.endsWith('.md')) continue;
+      const content = fs.readFileSync(path.join(yearDir, file), 'utf8');
+      const m = content.match(/pinecast\.com\/listen\/([a-f0-9-]{36})/);
+      if (m) ids.add(m[1]);
+    }
+  }
+  return ids;
+}
+
+function buildFrontmatter(fields) {
+  const lines = [
+    '---',
+    `title: "${fields.title.replace(/"/g, '\\"')}"`,
+    `date: "${fields.date}"`,
+    'categories:',
+    '  - "shows"',
+    `author: "${fields.author.replace(/"/g, '\\"')}"`,
+    'tags:',
+    `  - "${slugify(fields.author)}"`,
+  ];
+  if (fields.enclosure) lines.push(`enclosure: "${fields.enclosure}"`);
+  if (fields.coverImage) lines.push(`coverImage: "${fields.coverImage}"`);
+  if (fields.redirectFrom) lines.push(`redirectFrom: "${fields.redirectFrom}"`);
+  if (fields.episode) lines.push(`episode: ${fields.episode}`);
+  if (fields.season) lines.push(`season: ${fields.season}`);
+  lines.push(`explicit: "${fields.explicit || 'no'}"`);
+  if (fields.duration) lines.push(`duration: "${fields.duration}"`);
+  lines.push('---', '', fields.description, '');
+  return lines.join('\n');
+}
+
+async function main() {
+  const res = await fetch(FEED_URL, {
+    headers: { 'User-Agent': 'house-finesse-rss-bot/1.0' },
+  });
+  if (!res.ok) throw new Error(`RSS fetch failed: ${res.status} ${res.statusText}`);
+  const xml = await res.text();
+
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  const items = [];
+  let m;
+  while ((m = itemRegex.exec(xml)) !== null) items.push(m[1]);
+
+  if (items.length === 0) {
+    console.log('No items found in feed.');
+    return;
+  }
+
+  const existing = getExistingPinecastIds();
+  let created = 0;
+
+  for (const item of items) {
+    const enclosureUrl = extractAttr(item, 'enclosure', 'url');
+    const pinecastId = enclosureUrl.match(/pinecast\.com\/listen\/([a-f0-9-]{36})/)?.[1];
+
+    if (!pinecastId) continue;
+    if (existing.has(pinecastId)) continue;
+
+    const title = extractTag(item, 'title');
+    const pubDate = extractTag(item, 'pubDate');
+    const date = parseIsoDate(pubDate);
+    const year = date.slice(0, 4);
+
+    const author = extractTag(item, 'itunes:author') || extractTag(item, 'author');
+    const duration = extractTag(item, 'itunes:duration');
+    const episode = extractTag(item, 'itunes:episode');
+    const season = extractTag(item, 'itunes:season');
+    const explicit = extractTag(item, 'itunes:explicit') || 'no';
+    const description = extractTag(item, 'description');
+
+    const enclosureLength = extractAttr(item, 'enclosure', 'length');
+    const enclosureType = extractAttr(item, 'enclosure', 'type');
+    const enclosure = enclosureUrl
+      ? `${enclosureUrl} ${enclosureLength} ${enclosureType}`.trim()
+      : '';
+
+    const episodeCode = extractEpisodeCode(title);
+    const coverImage = deriveCoverImage(title, author);
+    const redirectFrom = episodeCode ? `/${episodeCode}` : '';
+    const slug = slugify(title);
+    const filename = `${date}-${slug}.md`;
+
+    const yearDir = path.join(POSTS_DIR, year);
+    if (!fs.existsSync(yearDir)) fs.mkdirSync(yearDir, { recursive: true });
+
+    const filepath = path.join(yearDir, filename);
+    if (fs.existsSync(filepath)) {
+      console.log(`Skipping (file exists): ${filename}`);
+      continue;
+    }
+
+    const content = buildFrontmatter({
+      title,
+      date,
+      author,
+      enclosure,
+      coverImage,
+      redirectFrom,
+      episode,
+      season,
+      explicit,
+      duration,
+      description,
+    });
+
+    fs.writeFileSync(filepath, content, 'utf8');
+    console.log(`Created: src/posts/${year}/${filename}`);
+    created++;
+  }
+
+  if (created === 0) {
+    console.log('No new episodes found.');
+  } else {
+    console.log(`Done. Created ${created} new post(s).`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
This PR adds an automated workflow to fetch new episodes from an RSS feed (Pinecast) and automatically create pull requests with new episode posts.

## Key Changes

- **New script: `scripts/rss-to-posts.js`**
  - Fetches episodes from a configurable RSS feed URL (defaults to Pinecast's House Finesse feed)
  - Parses RSS/XML items and extracts episode metadata (title, date, author, duration, etc.)
  - Converts HTML descriptions to Markdown
  - Downloads and caches cover images locally
  - Generates frontmatter-formatted Markdown post files organized by year
  - Deduplicates episodes using Pinecast IDs to avoid re-processing
  - Generates episode slugs from episode codes (e.g., "HF322-with-taiwo") with fallback to title-based slugs
  - Supports iTunes namespace tags for episode/season numbers and explicit content flags

- **New workflow: `.github/workflows/rss-new-episode.yml`**
  - Runs on a 2-hour schedule (configurable via cron) and manual trigger
  - Executes the RSS script to fetch new episodes
  - Detects new files and creates appropriately named feature branches
  - Automatically opens pull requests with:
    - Descriptive titles based on episode slug or date
    - Pre-filled checklist for review (content, images, tags)
    - List of new files created
  - Uses GitHub Actions bot for commits and PR creation

## Implementation Details

- **HTML to Markdown conversion** handles ordered/unordered lists, block elements (p, h1-h6), inline formatting (strong, em, links), and HTML entity decoding
- **Date parsing** converts ISO 8601 dates to YYYY-MM-DD format
- **Image handling** extracts filenames from URLs (handling query strings) and downloads to `src/img/cover-images/`
- **Deduplication** scans existing posts for Pinecast IDs to prevent duplicate episode creation
- **Flexible configuration** via `RSS_FEED_URL` environment variable (repository variable or default)
- **Graceful error handling** with informative console output and proper exit codes

https://claude.ai/code/session_01Pq82YGvHosDSnJ92i375Xd