### PR TITLE
Add HF326 episode with Taylan show notes and tracklist

### DIFF
--- a/src/posts/2026/2026-06-05-hf326-with-taylan.md
+++ b/src/posts/2026/2026-06-05-hf326-with-taylan.md
@@ -1,0 +1,41 @@
+---
+title: "HF326 with Taylan"
+date: "2026-06-05"
+categories:
+  - "shows"
+author: "Taylan"
+tags:
+  - "taylan"
+enclosure: "https://op3.dev/e/pinecast.com/listen/fb71ca0b-b6af-4faa-b4d9-0ae910ea0c4a.mp3?source=rss&ext=asset.mp3 63564447 audio/mpeg"
+coverImage: "HF326_with_Taylan.jpg"
+redirectFrom: "/hf326"
+episode: 23
+season: 26
+explicit: "yes"
+duration: "01:06:03"
+---
+If you're in Kettering this Saturday, catch Taylan live on the Dance till Dawn stage at The Music Barn festival (2–3pm) — tickets at musicbarn.co.uk.
+
+Taylan's in for this week's #FinesseFriday with a proper underground workout. Fabio Santos dominates the tracklist, with a Wiley and MJ Cole sendoff to close out in style.
+
+Hook up with Taylan and others inside our House Finesse VIP Club at patreon.com/housefinesse
+
+## Track Listing
+
+1. Rudi Maddox, Mack Maddox - M.P.D
+2. Fabio Santos - Afterimages [Hardline Sounds]
+3. Fabio Santos - Breather [Constant Black]
+4. Fabio Santos - Midnight Protocol [Constant Black]
+5. Oldboy, DJ Cosworth - Mastaplanz [Swingers]
+6. Ho Gosh - No Murdah
+7. Fabio Santos - Keep Jumping [Hardline Sounds]
+8. Burnski, Mikey Sebastian - Mind Your Business [Constant Sound]
+9. bullet tooth - All I Do
+10. Goulish - Freddy's Theme
+11. ZOIG - Obsession [ATW Records]
+12. Fabio Santos - The Jungle [Hardline Sounds]
+13. Fabio Santos - Outsider [Hardline Sounds]
+14. Malps - Curley Wurley
+15. Wiley, Local, Lucas Alexander - 8 For 8 [Rarebit Records]
+16. Malps - 421 Boys
+17. MJ Cole - Sincere (feat. Nova Caspar & Jay Dee) [Metrix / Talkin' Loud]


### PR DESCRIPTION
## Summary
Added a new episode post for HF326 featuring Taylan, including show metadata, episode description, and complete tracklist.

## Changes
- Created new episode post for Season 26, Episode 23 (HF326 with Taylan)
- Added episode metadata including:
  - Air date: June 5, 2026
  - Duration: 1 hour 6 minutes 3 seconds
  - Audio enclosure with MP3 link and file size
  - Cover image reference
  - Explicit content flag
- Included show description highlighting Taylan's live performance at The Music Barn festival and the underground workout tracklist
- Added complete 17-track listing with artist and label information
- Set up redirect from `/hf326` for backwards compatibility
- Added Patreon VIP Club promotion link

## Notable Details
- Episode features heavy rotation of Fabio Santos tracks (6 tracks)
- Marked as explicit content
- Includes live performance promotion for Kettering event

https://claude.ai/code/session_016NQouBgQKMdt5afvboHXPn