### PR TITLE
Add Wrangler configuration and feed redirect

### DIFF
--- a/src/_redirects
+++ b/src/_redirects
@@ -1,0 +1,1 @@
+/feed/ /feed/feed.xml 200

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "house-finesse"
+pages_build_output_dir = "public"
+compatibility_date = "2026-06-06"


### PR DESCRIPTION
## Summary
This PR adds Cloudflare Pages deployment configuration and sets up a URL redirect for the feed endpoint.

## Key Changes
- **wrangler.toml**: Added Wrangler configuration file with:
  - Project name: "house-finesse"
  - Pages build output directory: "public"
  - Compatibility date: "2026-06-06"
- **src/_redirects**: Added redirect rule to serve `/feed/` requests from `/feed/feed.xml` with a 200 status code (transparent rewrite)

## Implementation Details
The `_redirects` file uses Netlify/Cloudflare Pages redirect syntax to internally rewrite feed requests without changing the URL in the browser, allowing `/feed/` to transparently serve the `feed.xml` file.

https://claude.ai/code/session_01EWz6EmPWWmMAfYmHLhmkAn