### PR TITLE
Migrate feed redirect from plain text to Liquid config

### DIFF
--- a/src/_redirects
+++ b/src/_redirects
@@ -1,1 +1,0 @@
-/feed/ /feed/feed.xml 200

--- a/src/_redirects.liquid
+++ b/src/_redirects.liquid
@@ -8,6 +8,8 @@ eleventyExcludeFromCollections: true
 
 /wp-content/uploads/:year/:month/:slug /img/cover-images/:slug
 
+/feed/        /feed/feed.xml 200
+
 /shows/feed https://pinecast.com/feed/housefinesse
 /podcast/feed/ https://pinecast.com/feed/housefinesse
 /feed/podcast https://pinecast.com/feed/housefinesse


### PR DESCRIPTION
## Summary
Consolidated redirect configuration by migrating the `/feed/` redirect rule from a separate `_redirects` plain text file into the `_redirects.liquid` template file.

## Key Changes
- Moved the `/feed/ /feed/feed.xml 200` redirect rule from `src/_redirects` into `src/_redirects.liquid`
- Removed the now-empty `src/_redirects` file
- Maintains identical redirect behavior with centralized configuration

## Implementation Details
This change consolidates all redirect rules into a single Liquid template file, improving maintainability by having all redirects defined in one location rather than split across multiple files. The redirect rule itself remains functionally unchanged.

https://claude.ai/code/session_01EWz6EmPWWmMAfYmHLhmkAn