### PR TITLE
Fix duplicate redirectFrom and redirect rule ordering

### DIFF
--- a/src/_redirects.liquid
+++ b/src/_redirects.liquid
@@ -6,8 +6,6 @@ eleventyExcludeFromCollections: true
 /how-to-listen/   /follow
 /subscribe/       /follow
 
-/wp-content/uploads/:year/:month/:slug /img/cover-images/:slug
-
 /feed/        /feed/feed.xml 200
 
 /shows/feed https://pinecast.com/feed/housefinesse
@@ -25,6 +23,8 @@ eleventyExcludeFromCollections: true
 /substack         https://www.patreon.com/cw/HouseFinesseClub
 /club             https://www.patreon.com/cw/HouseFinesseClub
 /vip              https://www.patreon.com/cw/HouseFinesseClub
+
+/wp-content/uploads/:year/:month/:slug /img/cover-images/:slug
 
 
 {%- for page in collections.all -%}

--- a/src/_redirects.liquid
+++ b/src/_redirects.liquid
@@ -24,12 +24,12 @@ eleventyExcludeFromCollections: true
 /club             https://www.patreon.com/cw/HouseFinesseClub
 /vip              https://www.patreon.com/cw/HouseFinesseClub
 
-/wp-content/uploads/:year/:month/:slug /img/cover-images/:slug
-
 
 {%- for page in collections.all -%}
   {%- if page.url and page.data.redirectFrom %}
 {{ page.data.redirectFrom }}  {{ page.url | append: "?utm_source=redirect&utm_medium=web&utm_campaign=hf" }}
   {%- endif -%}
 {%- endfor -%}
+
+/wp-content/uploads/:year/:month/:slug /img/cover-images/:slug
 

--- a/src/posts/2023/2023-01-27-warm-up-the-dancefloor-with-disco77.md
+++ b/src/posts/2023/2023-01-27-warm-up-the-dancefloor-with-disco77.md
@@ -7,7 +7,7 @@ tags:
   - "disco77"
 enclosure: "https://pinecast.com/listen/585e32d0-6450-48a1-a69b-aaedab1c6e97.mp3 59754652 audio/mpeg "
 coverImage: "Warm-Up-The-Dancefloor-with-Disco77.jpg"
-redirectFrom: "/hf152"
+redirectFrom: "/hf153"
 ---
 
 **Don't let the cold get to you as Disco77 brings the heat on #FinesseFriday to warm up your weekend dancefloors.**


### PR DESCRIPTION
## Summary

- **Fix duplicate `/hf152`** — `2023-01-27-warm-up-the-dancefloor-with-disco77.md` had `redirectFrom: "/hf152"` but that value is already used by the Jan 20 episode. Changed to `/hf153` to match the weekly sequence (hf150=Jan 6, hf151=Jan 13, hf152=Jan 20, hf153=Jan 27). Cloudflare was silently discarding the duplicate, causing `/hf153` to be missing and `/hf152` to potentially resolve to the wrong post.
- **Fix placeholder rule ordering** — moved `/wp-content/uploads/:year/:month/:slug` to after all static rules. Cloudflare evaluates rules top-to-bottom and placeholder patterns slow down everything beneath them, generating build warnings for every static rule.

## Test plan

- [x] Confirm `/hf152` redirects to the Jan 20 "REWIND to Funky House Finesse 22" episode
- [x] Confirm `/hf153` redirects to the Jan 27 "Warm Up The Dancefloor with Disco77" episode
- [ ] Confirm no redirect warnings in Cloudflare build log about static rules being below placeholders
- [x] Spot-check a few other short URL redirects (e.g. `/hf325`, `/hf326`, `/whatsapp`)

https://claude.ai/code/session_01EWz6EmPWWmMAfYmHLhmkAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWz6EmPWWmMAfYmHLhmkAn)_