### PR TITLE
Add optional host display and improve footer styling

### DIFF
--- a/src/_data/meta.js
+++ b/src/_data/meta.js
@@ -1,5 +1,6 @@
 module.exports = {
   url: process.env.URL || "http://localhost:8080",
+  host: process.env.HOST || null,
   siteName: "House Finesse",
   siteDescription:
     "The longest running house music podcast since 2005",

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -201,7 +201,7 @@
           </div>
           <div class="footer-credits__website">
             <p>
-              <a href="https://github.com/si/hf" title="Versioned on Github">v{{ pkg.version }}</a>,
+              {% if meta.host %}<span>Hosted on {{ meta.host }}</span>, {% endif %}<a href="https://github.com/si/hf" title="v{{ pkg.version }}">Versioned on GitHub</a>,
               <a rel="me" href="https://unstyled.com/">Made by Unstyled Studios</a>
             </p>
           </div>

--- a/src/css/_layout.scss
+++ b/src/css/_layout.scss
@@ -98,6 +98,7 @@ footer {
       display: flex;
       align-items: center;
       justify-content: center;
+      font-size: 0.75rem;
 
       @media (min-width: 80ch) {
         justify-content: flex-end;


### PR DESCRIPTION
## Summary
This PR adds support for displaying an optional hosting provider in the footer and improves the footer credits styling.

## Key Changes
- **Footer metadata display**: Added conditional rendering of hosting provider information in the footer, controlled by the `HOST` environment variable
- **GitHub link improvement**: Updated the GitHub version link to display "Versioned on GitHub" as the link text while moving the version number to the title attribute
- **Footer styling**: Reduced the font size of footer credits to `0.75rem` for better visual hierarchy
- **Configuration**: Added `host` property to the meta data module that reads from the `HOST` environment variable (defaults to `null` if not set)

## Implementation Details
- The host display only renders when `meta.host` is defined, allowing flexible deployment across different hosting platforms
- The version information is now accessible via the link's title attribute for better accessibility
- Font size reduction applies to the entire footer credits section, creating a more refined footer appearance

https://claude.ai/code/session_013XwC5AGvqfcE1SosVTfxs3