### PR TITLE
Add HF332 episode with DJ Tai - Dirty Disco Funk mix

### DIFF
--- a/src/posts/2026/2026-07-17-hf332-with-dj-tai.md
+++ b/src/posts/2026/2026-07-17-hf332-with-dj-tai.md
@@ -16,7 +16,7 @@ explicit: "no"
 coverImage: "HF332_with_Taiwo.jpg"
 ---
 
-**DJ Tai is back with his "Dirty Disco Funk" mix, and the title says it all** — thirteen tracks of pure floor-filling groove, heavy on the edits and remixes from the disco underground's finest re-touchers.** 
+**DJ Tai is back with his "Dirty Disco Funk" mix, and the title says it all — thirteen tracks of pure floor-filling groove, heavy on the edits and remixes from the disco underground's finest re-touchers.**
 
 Dimitri From Paris bookends the set, opening with his take on "Le Freak" and later re-editing Harold Melvin & The Blue Notes into a Philly soul highlight. Los Charly's Orchestra pull double duty with two different sides of "Feeling High" and "Swinging To The Bass", while Grant Nelson gets his hands on Jamiroquai's "Runaway" for one of the set's biggest moments.
 

--- a/src/posts/2026/2026-07-17-hf332-with-dj-tai.md
+++ b/src/posts/2026/2026-07-17-hf332-with-dj-tai.md
@@ -8,6 +8,7 @@ tags:
   - "dj-tai"
   - "disco"
   - "funk"
+enclosure: "https://pinecast.com/listen/d19d20e7-c706-4495-97d7-5989f3685c28.mp3 58125667 audio/mpeg"
 redirectFrom: "/hf332"
 episode: 29
 season: 26

--- a/src/posts/2026/2026-07-17-hf332-with-dj-tai.md
+++ b/src/posts/2026/2026-07-17-hf332-with-dj-tai.md
@@ -1,5 +1,5 @@
 ---
-title: "HF332 Dirty Disco Funk with DJ Tai"
+title: "HF332 with DJ Tai"
 date: "2026-07-17"
 categories:
   - "shows"
@@ -14,7 +14,10 @@ season: 26
 explicit: "no"
 coverImage: "HF332_with_Taiwo.jpg"
 ---
-**DJ Tai is back with Dirty Disco Funk, and the title says it all** — thirteen tracks of pure floor-filling groove, heavy on the edits and remixes from the disco underground's finest re-touchers. Dimitri From Paris bookends the set, opening with his take on "Le Freak" and later re-editing Harold Melvin & The Blue Notes into a Philly soul highlight. Los Charly's Orchestra pull double duty with two different sides of "Feeling High" and "Swinging To The Bass", while Grant Nelson gets his hands on Jamiroquai's "Runaway" for one of the set's biggest moments.
+
+**DJ Tai is back with his "Dirty Disco Funk" mix, and the title says it all** — thirteen tracks of pure floor-filling groove, heavy on the edits and remixes from the disco underground's finest re-touchers.** 
+
+Dimitri From Paris bookends the set, opening with his take on "Le Freak" and later re-editing Harold Melvin & The Blue Notes into a Philly soul highlight. Los Charly's Orchestra pull double duty with two different sides of "Feeling High" and "Swinging To The Bass", while Grant Nelson gets his hands on Jamiroquai's "Runaway" for one of the set's biggest moments.
 
 There's plenty of remix pedigree throughout: Opolopo, Hardsoul, Timmy Vegas and Rob Hayes all bring their own flavour, and the closing run through Louie Vega, DJ Spen and Muthafunkaz keeps the deep disco energy going right to the last record.
 

--- a/src/posts/2026/2026-07-17-hf332-with-dj-tai.md
+++ b/src/posts/2026/2026-07-17-hf332-with-dj-tai.md
@@ -1,0 +1,37 @@
+---
+title: "HF332 Dirty Disco Funk with DJ Tai"
+date: "2026-07-17"
+categories:
+  - "shows"
+author: "Taiwo"
+tags:
+  - "dj-tai"
+  - "disco"
+  - "funk"
+redirectFrom: "/hf332"
+episode: 29
+season: 26
+explicit: "no"
+coverImage: "HF332_with_Taiwo.jpg"
+---
+**DJ Tai is back with Dirty Disco Funk, and the title says it all** — thirteen tracks of pure floor-filling groove, heavy on the edits and remixes from the disco underground's finest re-touchers. Dimitri From Paris bookends the set, opening with his take on "Le Freak" and later re-editing Harold Melvin & The Blue Notes into a Philly soul highlight. Los Charly's Orchestra pull double duty with two different sides of "Feeling High" and "Swinging To The Bass", while Grant Nelson gets his hands on Jamiroquai's "Runaway" for one of the set's biggest moments.
+
+There's plenty of remix pedigree throughout: Opolopo, Hardsoul, Timmy Vegas and Rob Hayes all bring their own flavour, and the closing run through Louie Vega, DJ Spen and Muthafunkaz keeps the deep disco energy going right to the last record.
+
+Dirty by name, funky by nature. Get into it.
+
+## Track Listing
+
+1. Dimitri From Paris - Le Freak
+2. Los Charly's Orchestra - Swinging To The Bass
+3. Let Me Do My Thang (Opolopo Remix)
+4. Hardsoul, Donna Washington - Take Me To The Disco (Hardsoul's Disco Revenge Mix)
+5. Los Charly's Orchestra - Feeling High (Balearic Disco Mix)
+6. Timmy Vegas - Get Yourself Together
+7. Dave Lee - Candidate For Love
+8. Jamiroquai - Runaway (Grant Nelson Remix)
+9. Soul Heaven (Rob Hayes Disco Dub Groove King Mix)
+10. Harold Melvin & The Blue Notes, Dimitri From Paris - Tell The World How I Feel About 'Cha Baby (Dimitri From Paris Disco Re-Edit)
+11. Sheila Ford, Louie Vega, DJ Spen - Why Can't You See
+12. Muthafunkaz, Marc Evans - You Can't Hide From Yourself
+13. Paul Getto - No Doubt About It


### PR DESCRIPTION
## Summary
Added a new show episode post for HF332 featuring DJ Tai's "Dirty Disco Funk" mix, a curated selection of disco and funk tracks with heavy emphasis on edits and remixes from underground producers.

## Changes
- Created new post file for HF332 episode (Season 26, Episode 29)
- Included complete track listing with 13 tracks featuring artists like Dimitri From Paris, Los Charly's Orchestra, Grant Nelson, and others
- Added episode metadata including audio enclosure link, cover image reference, and redirect alias
- Documented mix description highlighting the disco funk aesthetic and remix pedigree

## Details
- Episode date: July 17, 2026
- Audio format: MP3 (58.1 MB)
- Content marked as non-explicit
- Includes redirect from `/hf332` for backwards compatibility

https://claude.ai/code/session_01JsUxXujLyRfP7LnN9F9QTZ